### PR TITLE
fix: 🐛 bug in LinkedList's deleteHead method

### DIFF
--- a/src/data-structures/linked-list/__tests__/linked-list.spec.ts
+++ b/src/data-structures/linked-list/__tests__/linked-list.spec.ts
@@ -499,6 +499,19 @@ describe('LinkedList', () => {
       expect(linkedList.toString()).toBe('2,3');
       expect(linkedList.size).toBe(2);
     });
+
+    it('removes elements from the front correctly', () => {
+      // Arrange
+      linkedList.fromArray([1, 2]);
+
+      // Act and Assert
+      expect(linkedList.deleteHead()?.data).toBe(1);
+      expect(linkedList.deleteHead()?.data).toBe(2);
+      expect(linkedList.deleteHead()).toBeNull();
+
+      expect(linkedList.head).toBeNull();
+      expect(linkedList.tail).toBeNull();
+    });
   });
 
   describe('deleteTail', () => {

--- a/src/data-structures/linked-list/linked-list.ts
+++ b/src/data-structures/linked-list/linked-list.ts
@@ -150,6 +150,9 @@ export class LinkedList<T = any> extends BaseLinkedList<T, Node<T>> {
 
     if (deletedNode?.next) {
       this._head = deletedNode.next;
+    } else {
+      this._head = null;
+      this._tail = null;
     }
 
     this._size -= 1;


### PR DESCRIPTION
When calling the deleteHead method in LinkedList, the last remaining element was getting removed