### PR TITLE
fix: 🐛 bug in the DoublyLinkedList's deleteHead method

### DIFF
--- a/src/data-structures/doubly-linked-list/__tests__/doubly-linked-list.spec.ts
+++ b/src/data-structures/doubly-linked-list/__tests__/doubly-linked-list.spec.ts
@@ -524,6 +524,19 @@ describe('DoublyLinkedList', () => {
       expect(doublyLinkedList.toString()).toBe('2,3');
       expect(doublyLinkedList.size).toBe(2);
     });
+
+    it('removes elements from the end correctly', () => {
+      // Arrange
+      doublyLinkedList.fromArray([1, 2]);
+
+      // Act and Assert
+      expect(doublyLinkedList.deleteHead()?.data).toBe(1);
+      expect(doublyLinkedList.deleteHead()?.data).toBe(2);
+      expect(doublyLinkedList.deleteHead()).toBeNull();
+
+      expect(doublyLinkedList.head).toBeNull();
+      expect(doublyLinkedList.tail).toBeNull();
+    });
   });
 
   describe('deleteTail', () => {

--- a/src/data-structures/doubly-linked-list/doubly-linked-list.ts
+++ b/src/data-structures/doubly-linked-list/doubly-linked-list.ts
@@ -134,6 +134,9 @@ export class DoublyLinkedList<T = any> extends BaseLinkedList<T, Node<T>> {
     if (deletedNode?.next) {
       this._head = deletedNode.next;
       this._head.prev = null;
+    } else {
+      this._head = null;
+      this._tail = null;
     }
 
     this._size -= 1;


### PR DESCRIPTION
When calling the deleteHead method in LinkedList, the last remaining the element was getting removed.